### PR TITLE
Copy headers after install

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,3 +18,5 @@ export SCONSFLAGS+="FFTW_DIR=$PREFIX/lib PYBIND11_DIR=$PREFIX EIGEN_DIR=$PREFIX/
 
 scons
 scons install
+cp include/GalSim.h "$PREFIX/include"
+cp -r include/galsim "$PREFIX/include"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 0001-remove-run-install-checks.patch
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

The SCons install doesn't actually copy the headers by default, just the shared library. This copies the headers too.